### PR TITLE
20240816-1 - Feature / CDK Layout Breakpoint for Responsive Web Design, Dockerfile, Spindocker.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:16-alpine
+
+# create a working directory
+WORKDIR /usr/src/app
+
+# copy package.json to current directory
+COPY "package.json" .
+
+RUN npm install
+
+# add whatever that came out after npm i to current directory
+COPY . /usr/src/app
+
+RUN npm run build
+
+CMD ["npm", "run", "start"]
+
+EXPOSE 4200

--- a/spindocker.sh
+++ b/spindocker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+IMAGE_TAG="todo-img"
+# CONTAINER_NAME="todo-container"
+HOST_PORT=4200
+CONTAINER_PORT=4200
+
+# cleaning up previous process
+docker system prune
+
+# remove any previous existing image with the same tag
+docker rmi $IMAGE_TAG
+
+# build a new image with the custom tag
+docker build -t $IMAGE_TAG .
+
+# run a docker container based on the built image on specified container ar the mapped ports
+docker run -it -p $HOST_PORT:$CONTAINER_PORT $IMAGE_TAG

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,5 @@
-<span class="content">{{ title }} app is running!</span>
+<span class="{{ context | layout | async }} content"
+  >{{ title }} app is running!</span
+>
 
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,18 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { LayoutPipe } from './shared/pipes/layout/layout.pipe';
+import { AsyncPipe, JsonPipe } from '@angular/common';
+
+import { context } from './constants/layout.constants';
 
 @Component({
   standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, LayoutPipe, AsyncPipe, JsonPipe],
 })
 export class AppComponent {
   title = 'todo';
+  context = context;
 }

--- a/src/app/constants/layout.constants.ts
+++ b/src/app/constants/layout.constants.ts
@@ -1,0 +1,9 @@
+import { Breakpoints } from '@angular/cdk/layout';
+
+export const context: Record<string, string> = {
+  [Breakpoints.XSmall]: 'XSmall',
+  [Breakpoints.Small]: 'Small',
+  [Breakpoints.Medium]: 'Medium',
+  [Breakpoints.Large]: 'Large',
+  [Breakpoints.XLarge]: 'XLarge',
+};

--- a/src/app/shared/pipes/layout/layout.pipe.spec.ts
+++ b/src/app/shared/pipes/layout/layout.pipe.spec.ts
@@ -38,7 +38,6 @@ describe('LayoutPipe', () => {
   });
 
   it('should do something', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     spyOn(pipe['_breakpointObserver$'], 'observe').and.callFake(
       (
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/app/shared/pipes/layout/layout.pipe.spec.ts
+++ b/src/app/shared/pipes/layout/layout.pipe.spec.ts
@@ -1,0 +1,62 @@
+import {
+  BreakpointObserver,
+  Breakpoints,
+  BreakpointState,
+} from '@angular/cdk/layout';
+import { TestBed } from '@angular/core/testing';
+import { Observable, of, takeLast } from 'rxjs';
+
+import { LayoutPipe } from './layout.pipe';
+import { context } from 'src/app/constants/layout.constants';
+
+describe('LayoutPipe', () => {
+  let pipe: LayoutPipe;
+  let _breakpointObserver: BreakpointObserver;
+  const mockBreakpointState: BreakpointState = {
+    matches: true,
+    breakpoints: {
+      '(max-width: 599.98px)': false, // XSmall
+      '(min-width: 600px) and (max-width: 959.98px)': true, // Small
+      '(min-width: 960px) and (max-width: 1279.98px)': false, // Medium
+      '(min-width: 1280px) and (max-width: 1919.98px)': false, // Large
+      '(min-width: 1920px)': false, // XLarge
+    },
+  };
+
+  // testing pipe with DI
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BreakpointObserver],
+    });
+
+    _breakpointObserver = TestBed.get(BreakpointObserver);
+    pipe = new LayoutPipe(_breakpointObserver);
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should do something', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spyOn(pipe['_breakpointObserver$'], 'observe').and.callFake(
+      (
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _breakpoints = [
+          Breakpoints.XSmall,
+          Breakpoints.Small,
+          Breakpoints.Medium,
+          Breakpoints.Large,
+          Breakpoints.XLarge,
+        ]
+      ): Observable<BreakpointState> => of(mockBreakpointState)
+    );
+
+    pipe
+      .transform(context)
+      .pipe(takeLast(1))
+      .subscribe((result) => {
+        expect(result).toEqual('Small');
+      });
+  });
+});

--- a/src/app/shared/pipes/layout/layout.pipe.ts
+++ b/src/app/shared/pipes/layout/layout.pipe.ts
@@ -1,0 +1,36 @@
+import {
+  BreakpointObserver,
+  Breakpoints,
+  BreakpointState,
+} from '@angular/cdk/layout';
+import { Pipe, PipeTransform } from '@angular/core';
+import { map } from 'rxjs';
+
+@Pipe({
+  standalone: true,
+  name: 'layout',
+})
+export class LayoutPipe implements PipeTransform {
+  // DI on pipe should be done via constructor so that it can be injected on TestBed and tested
+  constructor(private _breakpointObserver$: BreakpointObserver) {}
+
+  transform(value: Record<string, string>) {
+    return this._breakpointObserver$
+      .observe([
+        Breakpoints.XSmall,
+        Breakpoints.Small,
+        Breakpoints.Medium,
+        Breakpoints.Large,
+        Breakpoints.XLarge,
+      ])
+      .pipe(
+        map((result: BreakpointState) => {
+          const viewWidthRange = Object.entries(result.breakpoints).filter(
+            (breakpoint) => breakpoint[1] === true
+          )[0][0];
+
+          return value[viewWidthRange];
+        })
+      );
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,3 +8,23 @@ body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
+
+.XSmall {
+  color: red;
+}
+
+.Small {
+  color: orange;
+}
+
+.Medium {
+  color: turquoise;
+}
+
+.Large {
+  color: greenyellow;
+}
+
+.XLarge {
+  color: blue;
+}


### PR DESCRIPTION
## Changes
* Added `layout.pipe` that implements Angular Material CDK Layout to map against Breakpoints Observer, which can be used to dynamically assign a css class regulated by the global styling;
* Added `Dockerfile`;
* Added `spindocker.sh` for creating docker image;
* Implement `layout.pipe` on `app.component`;
* Temporary global styling as PoC for host:context leveraging on `layout.pipe`.